### PR TITLE
DNS fixes (alias support and rh/ubuntu fixes) + Role by state configuration [6/26]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-hadoop.json
+++ b/chef/data_bags/crowbar/bc-template-hadoop.json
@@ -263,6 +263,12 @@
   "deployment": {
     "hadoop": {
       "crowbar-revision": 0,
+      "element_states": {
+        "hadoop-masternamenode": [ "readying", "ready", "applying" ],
+        "hadoop-secondarynamenode": [ "readying", "ready", "applying" ],
+        "hadoop-slavenode": [ "readying", "ready", "applying" ],
+        "hadoop-edgenode": [ "readying", "ready", "applying" ]
+      },
       "elements": {},
       "element_order": [
         [

--- a/chef/data_bags/crowbar/bc-template-hadoop.schema
+++ b/chef/data_bags/crowbar/bc-template-hadoop.schema
@@ -326,6 +326,16 @@
             "crowbar-revision": { "type": "int", "required": true },
             "crowbar-committing": { "type": "bool" },
             "crowbar-queued": { "type": "bool" },
+            "element_states": {
+              "type": "map",
+              "mapping": {
+                = : {
+                  "type": "seq",
+                  "required": true,
+                  "sequence": [ { "type": "str" } ]
+                }
+              }
+            },
             "elements": {
               "type": "map",
               "required": true,


### PR DESCRIPTION
This allows for the DNS barclamp to work correctly in ubuntu and redhat.

Update the barclamps to have element_states for mapping their roles to states for when to execute.

 chef/data_bags/crowbar/bc-template-hadoop.json   |    6 ++++++
 chef/data_bags/crowbar/bc-template-hadoop.schema |   10 ++++++++++
 2 files changed, 16 insertions(+), 0 deletions(-)
