### PR TITLE
Fix documentation references based on new layout [6/24]

### DIFF
--- a/crowbar_framework/doc/default/hadoop/barclamps/apachehadoop/hadoop.md
+++ b/crowbar_framework/doc/default/hadoop/barclamps/apachehadoop/hadoop.md
@@ -1,0 +1,5 @@
+### Hadoop Barclamp
+
+This barclamp does... 
+
+

--- a/crowbar_framework/doc/default/hadoop/licenses/apachehadoop/hadoop.md
+++ b/crowbar_framework/doc/default/hadoop/licenses/apachehadoop/hadoop.md
@@ -1,0 +1,10 @@
+### Hadoop Barclamp Licenses
+
+This file contains information (if updated by the barclamp authors!) about the licenses that apply to your installation.
+
+The following dependencies are required:
+
+* ?
+
+
+

--- a/crowbar_framework/doc/hadoop.yml
+++ b/crowbar_framework/doc/hadoop.yml
@@ -1,0 +1,4 @@
+# theses are the default meta_data values
+license:    Apache 2
+copyright:  2012 by Dell, Inc
+date:       September 15, 2012


### PR DESCRIPTION
This touches all the barclamps
to take advantage of the ability to discover document pages

 .../hadoop/barclamps/apachehadoop/hadoop.md        |    5 +++++
 .../default/hadoop/licenses/apachehadoop/hadoop.md |   10 ++++++++++
 crowbar_framework/doc/hadoop.yml                   |    4 ++++
 3 files changed, 19 insertions(+), 0 deletions(-)
